### PR TITLE
Accept "drkv"/"drkp" extended keys

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -647,11 +647,14 @@ def _CKD_pub(cK, c, s):
 
 BITCOIN_HEADER_PRIV = "0488ade4"
 BITCOIN_HEADER_PUB = "0488b21e"
+DASH_HEADER_PRIV = "02fe52f8"
+DASH_HEADER_PUB = "02fe52cc"
 
 TESTNET_HEADER_PRIV = "04358394"
 TESTNET_HEADER_PUB = "043587cf"
 
 BITCOIN_HEADERS = (BITCOIN_HEADER_PUB, BITCOIN_HEADER_PRIV)
+DASH_HEADERS = (DASH_HEADER_PUB, DASH_HEADER_PRIV)
 TESTNET_HEADERS = (TESTNET_HEADER_PUB, TESTNET_HEADER_PRIV)
 
 def _get_headers(testnet):
@@ -671,9 +674,9 @@ def deserialize_xkey(xkey):
     xkey_header = xkey[0:4].encode('hex')
     # Determine if the key is a bitcoin key or a testnet key.
     if xkey_header in TESTNET_HEADERS:
-        head = TESTNET_HEADER_PRIV
-    elif xkey_header in BITCOIN_HEADERS:
-        head = BITCOIN_HEADER_PRIV
+        head = [TESTNET_HEADER_PRIV]
+    elif xkey_header in BITCOIN_HEADERS or xkey_header in DASH_HEADERS:
+        head = [BITCOIN_HEADER_PRIV, DASH_HEADER_PRIV]
     else:
         raise Exception("Unknown xkey header: '%s'" % xkey_header)
 
@@ -681,7 +684,7 @@ def deserialize_xkey(xkey):
     fingerprint = xkey[5:9]
     child_number = xkey[9:13]
     c = xkey[13:13+32]
-    if xkey[0:4].encode('hex') == head:
+    if xkey[0:4].encode('hex') in head:
         K_or_k = xkey[13+33:]
     else:
         K_or_k = xkey[13+32:]

--- a/lib/tests/test_bitcoin.py
+++ b/lib/tests/test_bitcoin.py
@@ -6,7 +6,7 @@ from lib.bitcoin import (
     generator_secp256k1, point_to_ser, public_key_to_bc_address, EC_KEY,
     bip32_root, bip32_public_derivation, bip32_private_derivation, pw_encode,
     pw_decode, Hash, PoWHash, public_key_from_private_key, address_from_private_key,
-    is_valid, is_private_key, xpub_from_xprv, rev_hex)
+    is_valid, is_private_key, xpub_from_xprv, rev_hex, deserialize_xkey)
 
 try:
     import ecdsa
@@ -135,6 +135,33 @@ class Test_bitcoin(unittest.TestCase):
         result = xpub_from_xprv(xprv, testnet=True)
         self.assertEqual(result, xpub)
 
+    def test_deserialize_xkey(self):
+        xpub = "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
+        dash_xpub = "drkpS4muscpqe83Yft6RsgPzygCJngq3D8yfuQ8YhyCuisZXor5WxnnyP7s6DqpbuGwZA4fo3s72HBvV5dPYVABrCYWzwQETbpTMg4pfwVX9fTA"
+        for key in [xpub, dash_xpub]:
+            # depth = 5
+            # parent fingerprint = 0xd880d7d8
+            # child index = 1000000000
+            # chaincode = 0xc783e67b921d2beb8f6b389cc646d7263b4145701dadd2161548a8b078e65e9e
+            # pubkey = 0x022a471424da5e657499d1ff51cb43c47481a03b1e77f951fe64cec9f5a48f7011
+            expected = (5, 'd880d7d8'.decode('hex'), '3b9aca00'.decode('hex'),
+                        'c783e67b921d2beb8f6b389cc646d7263b4145701dadd2161548a8b078e65e9e'.decode('hex'),
+                        '022a471424da5e657499d1ff51cb43c47481a03b1e77f951fe64cec9f5a48f7011'.decode('hex'))
+            self.assertEqual(expected, deserialize_xkey(key))
+
+        xprv = "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76"
+        dash_xprv = "drkvjVe4RT6FJDdzF64gV69phbb1YSkaVRW74wrW3m39c3Fi48kteM3sDh42XeTWpaYyH67He1SUdg1fPJyaisEHJ2Q9xmorCEiP41tNKyfe2Uv"
+
+        for key in [xprv, dash_xprv]:
+            # depth = 5
+            # parent fingerprint = 0xd880d7d8
+            # child index = 1000000000
+            # chaincode = 0xc783e67b921d2beb8f6b389cc646d7263b4145701dadd2161548a8b078e65e9e
+            # privkey = 0x471b76e389e528d6de6d816857e012c5455051cad6660850e58372a6c3e6e7c8
+            expected = (5, 'd880d7d8'.decode('hex'), '3b9aca00'.decode('hex'),
+                        'c783e67b921d2beb8f6b389cc646d7263b4145701dadd2161548a8b078e65e9e'.decode('hex'),
+                        '471b76e389e528d6de6d816857e012c5455051cad6660850e58372a6c3e6e7c8'.decode('hex'))
+            self.assertEqual(expected, deserialize_xkey(key))
 
 class Test_keyImport(unittest.TestCase):
     """ The keys used in this class are TEST keys from

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1950,7 +1950,7 @@ class Wallet(object):
     @classmethod
     def is_xpub(self, text):
         try:
-            assert text[0:4] == 'xpub'
+            assert text[0:4] in ('xpub', 'drkp')
             deserialize_xkey(text)
             return True
         except:
@@ -1959,7 +1959,7 @@ class Wallet(object):
     @classmethod
     def is_xprv(self, text):
         try:
-            assert text[0:4] == 'xprv'
+            assert text[0:4] in ('xprv', 'drkv')
             deserialize_xkey(text)
             return True
         except:


### PR DESCRIPTION
Accept extended keys that begin with "xprv", "xpub", "drkv", or "drkp". This is an alternative PR to #7 which changes all keys to the *drk* format. Instead, with this PR we continue to use *xprv/xpub* but accept keys encoded with the *drk* prefix.