### PR TITLE
Merge Electrum 2.4.1

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -397,7 +397,7 @@ class ElectrumWindow(QMainWindow):
             b = os.path.basename(k)
             def loader(k):
                 return lambda: self.load_wallet_file(k)
-            self.recently_visited_menu.addAction(b, loader(k)).setShortcut(QKeySequence("Ctrl+%d"%i))
+            self.recently_visited_menu.addAction(b, loader(k)).setShortcut(QKeySequence("Ctrl+%d"%(i+1)))
         self.recently_visited_menu.setEnabled(len(recent))
 
     def init_menubar(self):

--- a/plugins/trezor.py
+++ b/plugins/trezor.py
@@ -148,7 +148,8 @@ class Plugin(BasePlugin):
 
     @hook
     def close_wallet(self):
-        self.window.statusBar().removeWidget(self.trezor_button)
+        if type(self.window) is ElectrumWindow:
+            self.window.statusBar().removeWidget(self.trezor_button)
 
     @hook
     def installwizard_load_wallet(self, wallet, window):


### PR DESCRIPTION
It seems there were two commits missing from Electrum 2.4.1 release:

4b9a149 recently visited wallets: increase shortcut index 
94ecf8d fix trezor statusbar 

Merged them now.