### PR TITLE
util: fix ambigious package name

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,5 +1,5 @@
 from version import ELECTRUM_VERSION
-from util import format_satoshis, print_msg, print_error, set_verbosity
+from electrum_dash.util import format_satoshis, print_msg, print_error, set_verbosity
 from wallet import Synchronizer, WalletStorage, Wallet, Imported_Wallet
 from coinchooser import COIN_CHOOSERS
 from network import Network, DEFAULT_SERVERS, DEFAULT_PORTS, pick_random_server

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -30,7 +30,7 @@ import re
 import hmac
 
 import version
-from util import print_error, InvalidPassword
+from electrum_dash.util import print_error, InvalidPassword
 
 import ecdsa
 import aes

--- a/lib/contacts.py
+++ b/lib/contacts.py
@@ -27,7 +27,7 @@ import dns
 
 import bitcoin
 import dnssec
-from util import StoreDict, print_error
+from electrum_dash.util import StoreDict, print_error
 from i18n import _
 
 

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -32,8 +32,8 @@ import jsonrpclib
 from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer, SimpleJSONRPCRequestHandler
 
 from network import Network
-from util import json_decode, DaemonThread
-from util import print_msg, print_error, print_stderr
+from electrum_dash.util import json_decode, DaemonThread
+from electrum_dash.util import print_msg, print_error, print_stderr
 from wallet import WalletStorage, Wallet
 from wizard import WizardBase
 from commands import known_commands, Commands

--- a/lib/dnssec.py
+++ b/lib/dnssec.py
@@ -182,7 +182,7 @@ dns.dnssec.validate = dns.dnssec._validate
 
 
 
-from util import print_error
+from electrum_dash.util import print_error
 
 
 # hard-coded root KSK

--- a/lib/masternode_manager.py
+++ b/lib/masternode_manager.py
@@ -7,8 +7,8 @@ import bitcoin
 from blockchain import Blockchain
 from masternode import MasternodeAnnounce, NetworkAddress
 from masternode_budget import BudgetProposal, BudgetVote
-from util import AlreadyHaveAddress, print_error
-from util import format_satoshis_plain
+from electrum_dash.util import AlreadyHaveAddress, print_error
+from electrum_dash.util import format_satoshis_plain
 
 BUDGET_FEE_CONFIRMATIONS = 6
 BUDGET_FEE_TX = 5 * bitcoin.COIN

--- a/lib/mnemonic.py
+++ b/lib/mnemonic.py
@@ -34,7 +34,7 @@ import string
 import ecdsa
 import pbkdf2
 
-from util import print_error
+from electrum_dash.util import print_error
 from bitcoin import is_old_seed, is_new_seed
 import version
 import i18n

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -42,7 +42,7 @@ except ImportError:
 
 import bitcoin
 import util
-from util import print_error
+from electrum_dash.util import print_error
 import transaction
 import x509
 import rsakey

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -4,7 +4,7 @@ import threading
 import os
 
 from copy import deepcopy
-from util import user_dir, print_error, print_msg, print_stderr, PrintError
+from electrum_dash.util import user_dir, print_error, print_msg, print_stderr, PrintError
 
 SYSTEM_CONFIG_PATH = "/etc/electrum-dash.conf"
 

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -28,7 +28,7 @@ from threading import Lock
 
 from bitcoin import Hash, hash_encode
 from transaction import Transaction
-from util import print_error, print_msg, ThreadJob
+from electrum_dash.util import print_error, print_msg, ThreadJob
 
 
 class Synchronizer(ThreadJob):

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -30,7 +30,7 @@
 
 import bitcoin
 from bitcoin import *
-from util import print_error, profiler
+from electrum_dash.util import print_error, profiler
 import time
 import sys
 import struct

--- a/lib/x509.py
+++ b/lib/x509.py
@@ -27,7 +27,7 @@
 from datetime import datetime
 import sys
 import util
-from util import profiler, print_error
+from electrum_dash.util import profiler, print_error
 import ecdsa
 import hashlib
 


### PR DESCRIPTION
This one haunted me: There are at least two packages named "util" and the ambigious import caused PyInstaller to produce undeterministic results.

Quite sure there are some more issues of these kind, but at least "util" is resolved for now.