### PR TITLE
Masternode Manager: Separate collateral payment into its own tab

### DIFF
--- a/lib/masternode_manager.py
+++ b/lib/masternode_manager.py
@@ -197,6 +197,8 @@ class MasternodeManager(object):
         mn = self.get_masternode(alias)
         if not mn:
             raise Exception('Nonexistent masternode')
+        if not mn.vin.get('prevout_hash'):
+            raise Exception('Collateral payment is not specified')
         if not mn.collateral_key:
             raise Exception('Collateral key is not specified')
         if not mn.delegate_key:


### PR DESCRIPTION
A new tab ("Choose Collateral") is used to scan for and choose
collateral payments for masternodes.

Also, some description strings have been changed to make them more helpful.