### PR TITLE
Trezor: Fix HidTransport call

### DIFF
--- a/plugins/trezor/plugin.py
+++ b/plugins/trezor/plugin.py
@@ -105,7 +105,7 @@ class TrezorCompatiblePlugin(HW_PluginBase):
             pair = [device.path, None]
 
         try:
-            transport = self.HidTransport(pair)
+            transport = self.hid_transport(pair)
         except BaseException as e:
             # We were probably just disconnected; never mind
             self.print_error("cannot connect at", device.path, str(e))

--- a/plugins/trezor/trezor.py
+++ b/plugins/trezor/trezor.py
@@ -15,7 +15,12 @@ class TrezorPlugin(TrezorCompatiblePlugin):
         from .client import TrezorClient as client_class
         import trezorlib.ckd_public as ckd_public
         from trezorlib.client import types
-        from trezorlib.transport_hid import HidTransport, DEVICE_IDS
+        from trezorlib.transport_hid import DEVICE_IDS
         libraries_available = True
     except ImportError:
         libraries_available = False
+
+    @classmethod
+    def hid_transport(cls, pair):
+        from trezorlib.transport_hid import HidTransport
+        return HidTransport(pair)


### PR DESCRIPTION
HidTransport is now a function in trezorlib. Fix this the same way that [Electrum](https://github.com/spesmilo/electrum/blob/master/plugins/trezor/trezor.py) has.